### PR TITLE
Load EasyUI assets in accordion layout

### DIFF
--- a/templates/Home/AccordionTreeIndex.html
+++ b/templates/Home/AccordionTreeIndex.html
@@ -7,6 +7,8 @@
         <link href="/Content/Images/favicon.ico" rel="shortcut icon" type="image/x-icon" />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/layui@2.8.18/dist/css/layui.css" />
         <link href="/Content/Scripts/showloading/showLoading.css" rel="stylesheet" type="text/css" />
+        <link href="/Content/Scripts/easyui/themes/default/easyui.css" rel="stylesheet" type="text/css" />
+        <link href="/Content/Scripts/easyui/themes/icon.css" rel="stylesheet" type="text/css" />
         <link href="/Content/Styles/common.css" rel="stylesheet" type="text/css" />
         <link href="/Content/Styles/iconNew16.css" rel="stylesheet" type="text/css" />
         <style>
@@ -271,6 +273,8 @@
         <div id="loadingGird" class="loading_background" style="display: none;"></div>
 
         <script type="text/javascript" src="/Content/Scripts/jquery-1.8.3.min.js"></script>
+        <script type="text/javascript" src="/Content/Scripts/easyui/jquery.easyui.min.js"></script>
+        <script type="text/javascript" src="/Content/Scripts/easyui/hpwf-easyui-extend.js"></script>
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/layui@2.8.18/dist/layui.js"></script>
         <script type="text/javascript" src="/Content/Scripts/jQuery.Ajax.js"></script>
         <script type="text/javascript" src="/Content/Scripts/hpwf-core.js"></script>


### PR DESCRIPTION
## Summary
- include the EasyUI theme and icon styles on the accordion layout home template so dialogs render correctly in the parent frame
- load the EasyUI script bundle and the hpwf helper extension immediately after jQuery to ensure $.hDialog is registered before downstream scripts execute

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68e1ecba5b60832c8afa20ce4e3195b7