### PR TITLE
Ensure EasyUI dialogs remain available for Layui shell

### DIFF
--- a/templates/Home/AccordionTreeIndex.html
+++ b/templates/Home/AccordionTreeIndex.html
@@ -275,6 +275,9 @@
         <script type="text/javascript" src="/Content/Scripts/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="/Content/Scripts/easyui/jquery.easyui.min.js"></script>
         <script type="text/javascript" src="/Content/Scripts/easyui/hpwf-easyui-extend.js"></script>
+        <script>
+            window.easyui$ = window.jQuery;
+        </script>
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/layui@2.8.18/dist/layui.js"></script>
         <script type="text/javascript" src="/Content/Scripts/jQuery.Ajax.js"></script>
         <script type="text/javascript" src="/Content/Scripts/hpwf-core.js"></script>
@@ -294,6 +297,15 @@
                 var util = layui.util;
                 var $ = layui.$;
                 var errorUrl = '/error/error404';
+
+                if (window.easyui$ && window.easyui$.hDialog) {
+                    window.$ = window.easyui$;
+                    window.jQuery = window.easyui$;
+                }
+
+                if (layui.$ && !layui.$.hDialog && window.easyui$ && window.easyui$.hDialog) {
+                    layui.$.hDialog = window.easyui$.hDialog;
+                }
 
                 HPWFIndex.init({
                     element: element,


### PR DESCRIPTION
## Summary
- capture the EasyUI-extended jQuery instance immediately after it loads
- promote the EasyUI copy to the global jQuery when dialog helpers are present
- mirror the dialog helper onto Layui's jQuery wrapper to keep shell integrations working

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1ef3d8130832c8ab542aafa727b3c