### PR TITLE
Ensure layui requests include AJAX header

### DIFF
--- a/Content/Area/FrameworkModules/Biz/UserAdmin.js
+++ b/Content/Area/FrameworkModules/Biz/UserAdmin.js
@@ -9,6 +9,8 @@ layui.use(['tree', 'table', 'layer', 'form', 'dropdown', 'util'], function () {
     var util = layui.util;
     var $ = layui.$;
 
+    var ajaxHeaders = { 'X-Requested-With': 'XMLHttpRequest' };
+
     var escapeHtml = typeof util.escape === 'function' ? util.escape : function (str) {
         return String(str || '')
             .replace(/&/g, '&amp;')
@@ -343,22 +345,27 @@ layui.use(['tree', 'table', 'layer', 'form', 'dropdown', 'util'], function () {
     }
 
     function initTree() {
-        $.getJSON('/Admin/FrameworkModules/OrganizeAdmin/GetOrganizeTreeJson/?isTree=1', function (data) {
-            var treeData = normalizeTree(data || []);
-            tree.render({
-                elem: '#organizeTree',
-                onlyIconControl: true,
-                data: treeData,
-                click: function (obj) {
-                    if (obj && obj.data) {
-                        state.organizeId = obj.data.id;
-                        reloadTable(true);
+        $.ajax({
+            url: '/Admin/FrameworkModules/OrganizeAdmin/GetOrganizeTreeJson/?isTree=1',
+            dataType: 'json',
+            headers: ajaxHeaders,
+            success: function (data) {
+                var treeData = normalizeTree(data || []);
+                tree.render({
+                    elem: '#organizeTree',
+                    onlyIconControl: true,
+                    data: treeData,
+                    click: function (obj) {
+                        if (obj && obj.data) {
+                            state.organizeId = obj.data.id;
+                            reloadTable(true);
+                        }
                     }
+                });
+                if (treeData.length) {
+                    state.organizeId = treeData[0].id;
+                    reloadTable(true);
                 }
-            });
-            if (treeData.length) {
-                state.organizeId = treeData[0].id;
-                reloadTable(true);
             }
         });
     }
@@ -393,6 +400,7 @@ layui.use(['tree', 'table', 'layer', 'form', 'dropdown', 'util'], function () {
                 organizeId: state.organizeId,
                 searchValue: state.searchValue
             },
+            headers: ajaxHeaders,
             parseData: function (res) {
                 if (typeof res === 'string') {
                     try {


### PR DESCRIPTION
## Summary
- define a shared AJAX header map for layui requests in UserAdmin.js
- configure the user table render call to send the XMLHttpRequest header
- load the organize tree via $.ajax with the same header for consistent behaviour

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2025d9b7c832cbb8ccbb2210149ea