### PR TITLE
Add backend route for toggling user enabled status

### DIFF
--- a/Content/Area/FrameworkModules/Biz/UserAdmin.js
+++ b/Content/Area/FrameworkModules/Biz/UserAdmin.js
@@ -462,7 +462,7 @@ layui.use(['tree', 'table', 'layer', 'form', 'dropdown', 'util'], function () {
             var userId = $elem.data('user-id');
             var original = Number($elem.data('original-enabled')) || 0;
             var newStatus = obj.elem.checked ? 1 : 0;
-            updateUserEnabled(userId, original, function (success) {
+            updateUserEnabled(userId, newStatus, original, function (success) {
                 if (success) {
                     $elem.data('original-enabled', newStatus);
                 } else {
@@ -491,12 +491,12 @@ layui.use(['tree', 'table', 'layer', 'form', 'dropdown', 'util'], function () {
         });
     }
 
-    function updateUserEnabled(userId, original, callback) {
+    function updateUserEnabled(userId, newStatus, original, callback) {
         if (!userId) {
             callback(false);
             return;
         }
-        $.ajaxjson('/FrameworkModules/UserAdmin/SetUserEnabled', 'userId=' + userId + '&isEnabled=' + original, function (d) {
+        $.ajaxjson('/Admin/FrameworkModules/UserAdmin/SetUserEnabled/', { userId: userId, isEnabled: newStatus }, function (d) {
             if (d.Success) {
                 layer.msg('状态更新成功');
                 reloadTable();

--- a/apps/hadmin/urls.py
+++ b/apps/hadmin/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
     url(r'^FrameworkModules/UserAdmin/SubmitForm/', UserAdminController.SubmitForm),
     url(r'^FrameworkModules/UserAdmin/GetEntity/', UserAdminController.GetEntity),
     url(r'^FrameworkModules/UserAdmin/Delete/', UserAdminController.Delete),
+    url(r'^FrameworkModules/UserAdmin/SetUserEnabled/', UserAdminController.SetUserEnabled),
     url(r'^FrameworkModules/UserAdmin/SetUserPassword/', UserAdminController.SetUserPassword),
     url(r'^FrameworkModules/UserAdmin/UserDimission/', UserAdminController.UserDimission),
     url(r'^FrameworkModules/UserAdmin/SetUserDimission/', UserAdminController.SetUserDimission),

--- a/apps/hadmin/views/FramworkModules/UserAdminController_view.py
+++ b/apps/hadmin/views/FramworkModules/UserAdminController_view.py
@@ -270,6 +270,49 @@ def Delete(request):
         response.content = json.dumps({'Success': False, 'Data': '0', 'Message': FrameworkMessage.MSG3020})
         return response
 
+@AjaxOnly
+@LoginAuthorize
+def SetUserEnabled(request):
+    userId = request.POST.get('userId', '')
+    isEnabledValue = request.POST.get('isEnabled', '')
+
+    if not userId:
+        response = HttpResponse()
+        response.content = json.dumps({'Success': False, 'Data': '0', 'Message': FrameworkMessage.MSG3020})
+        return response
+
+    if isinstance(isEnabledValue, str):
+        if isEnabledValue.lower() in ('1', 'true', 't', 'yes', 'y', 'on'):
+            isEnabled = 1
+        elif isEnabledValue.lower() in ('0', 'false', 'f', 'no', 'n', 'off'):
+            isEnabled = 0
+        else:
+            try:
+                isEnabled = 1 if int(isEnabledValue) else 0
+            except (TypeError, ValueError):
+                isEnabled = 1
+    else:
+        try:
+            isEnabled = 1 if int(isEnabledValue) else 0
+        except (TypeError, ValueError):
+            isEnabled = 1
+
+    response = HttpResponse()
+    currentUser = CommonUtils.Current(response, request)
+
+    updateFields = {'enabled': isEnabled, 'modifiedon': datetime.datetime.now()}
+    if currentUser:
+        updateFields['modifieduserid'] = currentUser.Id
+        updateFields['modifiedby'] = currentUser.RealName
+
+    rows = Piuser.objects.filter(id=userId).update(**updateFields)
+
+    if rows:
+        response.content = json.dumps({'Success': True, 'Data': str(isEnabled), 'Message': FrameworkMessage.MSG3010})
+    else:
+        response.content = json.dumps({'Success': False, 'Data': '0', 'Message': FrameworkMessage.MSG3020})
+    return response
+
 @LoginAuthorize
 def SetUserPassword(request):
     userId = ''


### PR DESCRIPTION
## Summary
- add a SetUserEnabled action in the UserAdmin controller that updates the enabled flag and returns the standard AJAX response payload
- expose the new action under /Admin/FrameworkModules/UserAdmin/SetUserEnabled/
- update UserAdmin.js to call the new admin route with the expected POST payload when toggling a user

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e202f8563c832c882ad119f466fe6a