### PR TITLE
Fix pagination defaults for user admin view

### DIFF
--- a/apps/hadmin/tests/test_user_admin_pagination.py
+++ b/apps/hadmin/tests/test_user_admin_pagination.py
@@ -1,0 +1,19 @@
+import unittest
+from types import SimpleNamespace
+
+from apps.hadmin.views.utils import get_pagination_params
+
+
+class PaginationParamsTests(unittest.TestCase):
+
+    def test_missing_rows_defaults_to_20(self):
+        request = SimpleNamespace(POST={})
+
+        page, rows = get_pagination_params(request, page_default=1, rows_default=20)
+
+        self.assertEqual(page, 1)
+        self.assertEqual(rows, 20)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apps/hadmin/views/FramworkModules/UserAdminController_view.py
+++ b/apps/hadmin/views/FramworkModules/UserAdminController_view.py
@@ -25,6 +25,7 @@ from apps.utilities.publiclibrary.SystemInfo import SystemInfo
 from apps.bizlogic.service.permission.ScopPermission import ScopPermission
 from apps.bizlogic.service.base.UserRoleService import UserRoleService
 from apps.bizlogic.service.base.SequenceService import SequenceService
+from apps.hadmin.views.utils import get_pagination_params
 
 
 def GenerateSplitTool():
@@ -99,15 +100,7 @@ def GetUserPageDTByDepartmentId(request):
     except:
         searchValue = ''
 
-    try:
-        page = request.POST['page']
-    except:
-        page = 1
-
-    try:
-        rows = request.POST['rows']
-    except:
-        rwos = 20
+    page, rows = get_pagination_params(request, page_default=1, rows_default=20)
 
     searchValue = searchValue if searchValue else ''
 
@@ -137,15 +130,7 @@ def GetUserListByPage(request):
     sort = None
     order = None
     filter = None
-    try:
-        page = request.POST['page']
-    except:
-        page = 1
-
-    try:
-        rows = request.POST['rows']
-    except:
-        rows = 50
+    page, rows = get_pagination_params(request, page_default=1, rows_default=50)
 
     try:
         sort = request.POST['sort']

--- a/apps/hadmin/views/utils.py
+++ b/apps/hadmin/views/utils.py
@@ -1,0 +1,18 @@
+"""Utility helpers for hadmin views."""
+
+from typing import Tuple, Any
+
+
+def _to_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def get_pagination_params(request, page_default: int = 1, rows_default: int = 20) -> Tuple[int, int]:
+    """Return pagination parameters as integers with safe fallbacks."""
+    page_value = getattr(request, 'POST', {}).get('page', page_default)
+    rows_value = getattr(request, 'POST', {}).get('rows', rows_default)
+
+    return _to_int(page_value, page_default), _to_int(rows_value, rows_default)


### PR DESCRIPTION
## Summary
- ensure the UserAdmin view falls back to 20 rows and normalises pagination parameters before service calls
- add a reusable pagination helper for hadmin views along with a regression test for missing rows input

## Testing
- python -m unittest apps.hadmin.tests.test_user_admin_pagination

------
https://chatgpt.com/codex/tasks/task_e_68e203ddfb54832cb503d18e25e6931c