### PR TITLE
Ensure Layui ajax attaches CSRF token

### DIFF
--- a/Content/Area/FrameworkModules/Biz/UserAdmin.js
+++ b/Content/Area/FrameworkModules/Biz/UserAdmin.js
@@ -11,6 +11,64 @@ layui.use(['tree', 'table', 'layer', 'form', 'dropdown', 'util'], function () {
 
     var ajaxHeaders = { 'X-Requested-With': 'XMLHttpRequest' };
 
+    function getCookie(name) {
+        var cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            var cookies = document.cookie.split(';');
+            for (var i = 0; i < cookies.length; i++) {
+                var cookie = cookies[i].trim();
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+
+    function csrfSafeMethod(method) {
+        return /^(GET|HEAD|OPTIONS|TRACE)$/.test(method);
+    }
+
+    function isSameOrigin(url) {
+        if (!url) {
+            return true;
+        }
+        var host = document.location.host;
+        var protocol = document.location.protocol;
+        var srOrigin = '//' + host;
+        var origin = protocol + srOrigin;
+        return url === origin || url.indexOf(origin + '/') === 0 ||
+            url === srOrigin || url.indexOf(srOrigin + '/') === 0 ||
+            !(/^(\/\/|http:|https:).*/.test(url));
+    }
+
+    function attachLayuiAjaxCsrf($instance, token) {
+        if (!$instance || typeof $instance.ajaxPrefilter !== 'function') {
+            return;
+        }
+        if ($instance.__csrfPrefilterAttached) {
+            return;
+        }
+        $instance.__csrfPrefilterAttached = true;
+        $instance.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+            var method = (options.type || '').toUpperCase();
+            if (!csrfSafeMethod(method) && isSameOrigin(options.url)) {
+                jqXHR.setRequestHeader('X-CSRFToken', token);
+            }
+            jqXHR.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+        });
+    }
+
+    var csrfToken = getCookie('csrftoken');
+    if (csrfToken) {
+        ajaxHeaders['X-CSRFToken'] = csrfToken;
+        attachLayuiAjaxCsrf($, csrfToken);
+    }
+    if (typeof $.ajaxSetup === 'function') {
+        $.ajaxSetup({ headers: ajaxHeaders });
+    }
+
     var escapeHtml = typeof util.escape === 'function' ? util.escape : function (str) {
         return String(str || '')
             .replace(/&/g, '&amp;')


### PR DESCRIPTION
## Summary
- attach a CSRF-aware ajaxPrefilter to the Layui jQuery instance so all POST requests carry the X-CSRFToken header
- keep Layui ajax default headers aligned with the existing jQuery configuration to satisfy Django's CSRF middleware

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e205d3420c832cb0fe2be93fd60670